### PR TITLE
Update about page, link from front page

### DIFF
--- a/content/en/page/about.md
+++ b/content/en/page/about.md
@@ -9,10 +9,12 @@ hideMeta: true
 
 SATRE (Standardised Architecture for Trusted Research Environments) started as a DARE UK Driver Project working to standardise access to secure data in trusted research environments, and included University of Dundee, Alan Turing Institute, UCL, Ulster University, and Research Data Scotland.
 
-Version 1.0 of SATRE was published last year, and we're now working on refining it with the goal of published version 2.0 this year.
+Version 1.0 of SATRE was published in 2023, and we're now working on refining it with the goal of published version 2.0 this year.
 We are also working with interested parties to help them evaluate or build their own TREs and related infrastructure.
 
 - SATRE specification https://satre-specification.readthedocs.io/
 - SATRE GitHub organisation https://github.com/sa-tre
 - Medium blog https://medium.com/satre
 - SATRE email discussion list https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-SATRE&A=1
+
+Most of our events are open to everyone including the general public, and will be advertised via major TRE communities including [UK TRE](https://www.uktre.org/), [Safe Data Access Professionals](https://securedatagroup.org/), and [HDR UK](https://www.hdruk.ac.uk/) newsletters.

--- a/content/en/page/about.md
+++ b/content/en/page/about.md
@@ -12,6 +12,7 @@ SATRE (Standardised Architecture for Trusted Research Environments) started as a
 Version 1.0 of SATRE was published last year, and we're now working on refining it with the goal of published version 2.0 this year.
 We are also working with interested parties to help them evaluate or build their own TREs and related infrastructure.
 
-- SATRE specification https://satre-specification.readthedocs.io/en/stable/
+- SATRE specification https://satre-specification.readthedocs.io/
 - SATRE GitHub organisation https://github.com/sa-tre
 - Medium blog https://medium.com/satre
+- SATRE email discussion list https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-SATRE&A=1

--- a/hugo.toml
+++ b/hugo.toml
@@ -85,29 +85,6 @@ DefaultContentLanguageInSubdir = true
   # This setting can also be in page's markdown file
   hidePageThumbnail = true
 
-# Comments system
-[params.comments]
-  # Supports disqus, giscus and utterances
-  # Check hugo docs for setting up disqus
-  system = "giscus"
-
-  # Options for giscus, exclude hyphens
-  repo = ""
-  repoid = ""
-  category = ""
-  categoryid = ""
-  mapping = ""
-  strict = ""
-  reactionsenabled = ""
-  emitmetadata = ""
-  inputposition = ""
-  theme = ""
-
-  # Options for utterances, exclude hyphens
-  # repo = ""
-  # issueterm = ""
-  # theme = ""
-
 [params.homepage.social]
   # Global params common for both languages
   title = "Follow me"
@@ -116,12 +93,19 @@ DefaultContentLanguageInSubdir = true
   [[params.homepage.social.icons]]
     website = "github"
     url = "https://github.com/sa-tre"
+    label = "GitHub"
   [[params.homepage.social.icons]]
     website = "medium"
     url = "https://medium.com/satre"
+    label = "Medium"
   [[params.homepage.social.icons]]
     website = "youtube"
     url = "https://www.youtube.com/watch?v=auExNHEGwcc"
+    label = "YouTube"
+  [[params.homepage.social.icons]]
+    website = "email"
+    url = "https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-SATRE&A=1"
+    label = "Mailing list"
 
 [[menu.main]]
   name = "About"

--- a/hugo.toml
+++ b/hugo.toml
@@ -56,7 +56,7 @@ DefaultContentLanguageInSubdir = true
   ]
 
   # Custom copyright - optional
-  copyright = "Copyright © 2024 - SATRE - CC-BY-4.0"
+  copyright = "Copyright © 2025 - SATRE - CC-BY-4.0"
   favicon = "/favicon.svg"
 
   # Color for the intro details and social links block, not applicable for dark mode

--- a/hugo.toml
+++ b/hugo.toml
@@ -15,7 +15,9 @@ DefaultContentLanguageInSubdir = true
     [languages.en.params]
       introTitle = "Standard Architecture for Trusted Research Environments (SATRE)"
       introSubtitle = "Working to standardise access to secure data in trusted research environments."
+      introLinkToContent = "👉 <a href='./page/about'>See the about page to find out more.</a>"
       introPhoto = "satre_logo_dark.svg"
+      introLinkToPage = "page/about"
       logo = "satre_logo_dark.svg"
     [[languages.en.menu.main]]
         name = "News"

--- a/themes/blist-satre/assets/css/styles.css
+++ b/themes/blist-satre/assets/css/styles.css
@@ -52,4 +52,8 @@
   a:empty {
     display: none;
   }
+
+  a {
+    @apply hover:text-red-600;
+  }
 }

--- a/themes/blist-satre/layouts/partials/intro.html
+++ b/themes/blist-satre/layouts/partials/intro.html
@@ -3,7 +3,8 @@
     <div>
       <h1 class="text-4xl font-bold mb-4">{{ .Site.Params.introTitle | safeHTML}}</h1>
       <p class="font-light text-lg">{{ .Site.Params.introSubtitle | safeHTML}}</p>
+      <p class="font-bold text-lg">{{ .Site.Params.introLinkToContent | safeHTML}}</p>
     </div>
-    <img class="rounded-lg shadow-sm" src="{{ .Site.Params.introPhoto | relURL }}" alt="{{ .Site.Title }}" />
+    <a href="{{ relref . .Site.Params.introLinkToPage }}"><img class="rounded-lg shadow-sm" src="{{ .Site.Params.introPhoto | relURL }}" alt="{{ .Site.Title }}" /></a>
   </div>
 </section>

--- a/themes/blist-satre/layouts/partials/social.html
+++ b/themes/blist-satre/layouts/partials/social.html
@@ -1,6 +1,6 @@
 <div class="{{ .Site.Params.ascentColor | default "bg-pink-50" }} dark:bg-gray-900">
-  <div class="container px-4 py-12 mx-auto max-w-4xl grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
-    <div>
+  <div class="flex px-8 py-12 mx-auto max-w-4xl gap-8 items-center">
+    <div class="px-8">
       <div class="text-2xl font-bold mb-2">{{ .Site.Params.homepage.social.title }}</div>
       <p class="opacity-60">{{ .Site.Params.homepage.social.description }}</p>
     </div>
@@ -8,15 +8,16 @@
     <ul class="flex justify-center gap-x-3 flex-wrap gap-y-2">
       {{range .Site.Params.homepage.social.icons}}
 
-      {{ if eq .website "twitter" }}
       <li>
         <a
           href="{{ .url }}"
           target="_blank"
           rel="noopener"
-          aria-label="Twitter"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
+          aria-label="{{ .label | default .website }}"
+          class="p-2 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300 flex"
         >
+
+          {{ if eq .website "twitter" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -33,19 +34,9 @@
               d="M22 4.01c-1 .49 -1.98 .689 -3 .99c-1.121 -1.265 -2.783 -1.335 -4.38 -.737s-2.643 2.06 -2.62 3.737v1c-3.245 .083 -6.135 -1.395 -8 -4c0 0 -4.182 7.433 4 11c-1.872 1.247 -3.739 2.088 -6 2c3.308 1.803 6.913 2.423 10.034 1.517c3.58 -1.04 6.522 -3.723 7.651 -7.742a13.84 13.84 0 0 0 .497 -3.753c-.002 -.249 1.51 -2.772 1.818 -4.013z"
             />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "mastodon" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Mastodon"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "mastodon" }}
         <svg 
           xmlns="http://www.w3.org/2000/svg" 
           width="24" 
@@ -61,19 +52,9 @@
           <path d="M18.648 15.254c-1.816 1.763 -6.648 1.626 -6.648 1.626a18.262 18.262 0 0 1 -3.288 -.256c1.127 1.985 4.12 2.81 8.982 2.475c-1.945 2.013 -13.598 5.257 -13.668 -7.636l-.026 -1.154c0 -3.036 .023 -4.115 1.352 -5.633c1.671 -1.91 6.648 -1.666 6.648 -1.666s4.977 -.243 6.648 1.667c1.329 1.518 1.352 2.597 1.352 5.633s-.456 4.074 -1.352 4.944z"></path>
           <path d="M12 11.204v-2.926c0 -1.258 -.895 -2.278 -2 -2.278s-2 1.02 -2 2.278v4.722m4 -4.722c0 -1.258 .895 -2.278 2 -2.278s2 1.02 2 2.278v4.722"></path>
        </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "linkedin" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="LinkedIn"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "linkedin" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -92,19 +73,9 @@
             <line x1="12" y1="16" x2="12" y2="11" />
             <path d="M16 16v-3a2 2 0 0 0 -4 0" />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "xing" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="xing"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "xing" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -119,19 +90,9 @@
             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
             <path d="M14.48736,22.8L9.65664,14.33208L17.154,1.2H22.2L14.70288,14.33208L19.53384,22.8H14.48736z M6.55728,16.26888l3.74808-6.17064l-2.81088-4.9512 H2.73696l2.81112,4.9512L1.8,16.26888H6.55728z"/>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "github" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="GitHub"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "github" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -148,19 +109,9 @@
               d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6c-.6 .6 -.6 1.2 -.5 2v3.5"
             />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "telegram" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Telegram"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "telegram" }}
            <svg
             xmlns="http://www.w3.org/2000/svg"
             class="icon icon-tabler icon-tabler-brand-telegram"
@@ -174,19 +125,9 @@
             stroke-linejoin="round"
           >
             <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/>          </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "buymeacoffee" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Buy Me A Coffee"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "buymeacoffee" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -201,19 +142,9 @@
             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
             <path d="M20.216 6.415l-.132-.666c-.119-.598-.388-1.163-1.001-1.379-.197-.069-.42-.098-.57-.241-.152-.143-.196-.366-.231-.572-.065-.378-.125-.756-.192-1.133-.057-.325-.102-.69-.25-.987-.195-.4-.597-.634-.996-.788a5.723 5.723 0 00-.626-.194c-1-.263-2.05-.36-3.077-.416a25.834 25.834 0 00-3.7.062c-.915.083-1.88.184-2.75.5-.318.116-.646.256-.888.501-.297.302-.393.77-.177 1.146.154.267.415.456.692.58.36.162.737.284 1.123.366 1.075.238 2.189.331 3.287.37 1.218.05 2.437.01 3.65-.118.299-.033.598-.073.896-.119.352-.054.578-.513.474-.834-.124-.383-.457-.531-.834-.473-.466.074-.96.108-1.382.146-1.177.08-2.358.082-3.536.006a22.228 22.228 0 01-1.157-.107c-.086-.01-.18-.025-.258-.036-.243-.036-.484-.08-.724-.13-.111-.027-.111-.185 0-.212h.005c.277-.06.557-.108.838-.147h.002c.131-.009.263-.032.394-.048a25.076 25.076 0 013.426-.12c.674.019 1.347.067 2.017.144l.228.031c.267.04.533.088.798.145.392.085.895.113 1.07.542.055.137.08.288.111.431l.319 1.484a.237.237 0 01-.199.284h-.003c-.037.006-.075.01-.112.015a36.704 36.704 0 01-4.743.295 37.059 37.059 0 01-4.699-.304c-.14-.017-.293-.042-.417-.06-.326-.048-.649-.108-.973-.161-.393-.065-.768-.032-1.123.161-.29.16-.527.404-.675.701-.154.316-.199.66-.267 1-.069.34-.176.707-.135 1.056.087.753.613 1.365 1.37 1.502a39.69 39.69 0 0011.343.376.483.483 0 01.535.53l-.071.697-1.018 9.907c-.041.41-.047.832-.125 1.237-.122.637-.553 1.028-1.182 1.171-.577.131-1.165.2-1.756.205-.656.004-1.31-.025-1.966-.022-.699.004-1.556-.06-2.095-.58-.475-.458-.54-1.174-.605-1.793l-.731-7.013-.322-3.094c-.037-.351-.286-.695-.678-.678-.336.015-.718.3-.678.679l.228 2.185.949 9.112c.147 1.344 1.174 2.068 2.446 2.272.742.12 1.503.144 2.257.156.966.016 1.942.053 2.892-.122 1.408-.258 2.465-1.198 2.616-2.657.34-3.332.683-6.663 1.024-9.995l.215-2.087a.484.484 0 01.39-.426c.402-.078.787-.212 1.074-.518.455-.488.546-1.124.385-1.766zm-1.478.772c-.145.137-.363.201-.578.233-2.416.359-4.866.54-7.308.46-1.748-.06-3.477-.254-5.207-.498-.17-.024-.353-.055-.47-.18-.22-.236-.111-.71-.054-.995.052-.26.152-.609.463-.646.484-.057 1.046.148 1.526.22.577.088 1.156.159 1.737.212 2.48.226 5.002.19 7.472-.14.45-.06.899-.13 1.345-.21.399-.072.84-.206 1.08.206.166.281.188.657.162.974a.544.544 0 01-.169.364zm-6.159 3.9c-.862.37-1.84.788-3.109.788a5.884 5.884 0 01-1.569-.217l.877 9.004c.065.78.717 1.38 1.5 1.38 0 0 1.243.065 1.658.065.447 0 1.786-.065 1.786-.065.783 0 1.434-.6 1.499-1.38l.94-9.95a3.996 3.996 0 00-1.322-.238c-.826 0-1.491.284-2.26.613z"/>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "medium" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Medium"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "medium" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -233,19 +164,9 @@
             <line x1="9" y1="9" x2="9" y2="15" />
             <line x1="15" y1="9" x2="15" y2="15" />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "reddit" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Medium"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "reddit" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -267,19 +188,9 @@
             <circle cx="15" cy="13" r=".5" fill="currentColor" />
             <path d="M10 17c.667 .333 1.333 .5 2 .5s1.333 -.167 2 -.5" />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "dribbble" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Dribbble"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "dribbble" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="icon icon-tabler icon-tabler-brand-dribbble"
@@ -298,19 +209,9 @@
             <path d="M6.4 19c3.5 -3.5 6 -6.5 14.5 -6.4" />
             <path d="M3.1 10.75c5 0 9.814 -.38 15.314 -5" />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "youtube" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="YouTube"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "youtube" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="icon icon-tabler icon-tabler-brand-youtube"
@@ -327,19 +228,9 @@
             <circle cx="12" cy="12" r="9" />
             <path d="M10 9l5 3l-5 3z" />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "instagram" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Instagram"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "instagram" }}
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="icon icon-tabler icon-tabler-brand-instagram"
@@ -357,19 +248,9 @@
             <circle cx="12" cy="12" r="9" />
             <path d="M10 9l5 3l-5 3z" />
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "stackoverflow" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="stackoverflow"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "stackoverflow" }}
           <svg xmlns="http://www.w3.org/2000/svg"
               class="icon icon-tabler icon-tabler-brand-stackoverflow"
               width="23"
@@ -384,19 +265,9 @@
             <polygon points="-108.5,56.2 -108.5,46.3 -105.2,46.3 -105.2,59.5 -135,59.5 -135,46.3 -131.7,46.3 -131.7,56.2       "/>
             <path d="M-128,45.4l16.2,3.4l0.7-3.2l-16.2-3.4L-128,45.4z M-125.9,37.6l15,7l1.4-3l-15-7L-125.9,37.6z     M-121.7,30.2l12.7,10.6l2.1-2.5l-12.7-10.6L-121.7,30.2z M-113.5,22.4l-2.7,2l9.9,13.3l2.7-2L-113.5,22.4z M-128.4,52.9h16.6    v-3.3h-16.6V52.9z"/>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "xda" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="XDA"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "xda" }}
            <svg
             xmlns="http://www.w3.org/2000/svg"
             class="icon icon-tabler icon-tabler-brand-xda"
@@ -411,19 +282,9 @@
           >
             <path d="M13.84 3.052V0h7.843v17.583H13.84v-3.024h4.591V3.052zM5.569 14.53V3.024h4.592V0H2.318v17.583H6.98L10.16 24v-9.483z"/>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "tiktok" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Tiktok"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "tiktok" }}
           <svg xmlns="http://www.w3.org/2000/svg"
               class="icon icon-tabler icon-tabler-brand-tiktok"
               width="23"
@@ -434,19 +295,9 @@
               fill="none">
             <path d="M448,209.91a210.06,210.06,0,0,1-122.77-39.25V349.38A162.55,162.55,0,1,1,185,188.31V278.2a74.62,74.62,0,1,0,52.23,71.18V0l88,0a121.18,121.18,0,0,0,1.86,22.17h0A122.18,122.18,0,0,0,381,102.39a121.43,121.43,0,0,0,67,20.14Z"/>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "googlescholar" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Google Scholar"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "googlescholar" }}
           <svg xmlns="http://www.w3.org/2000/svg"
               class="icon icon-tabler icon-tabler-brand-googlescholar"
               width="22"
@@ -457,36 +308,16 @@
               fill="none">
             <path d="M5.242 13.769L0 9.5 12 0l12 9.5-5.242 4.269C17.548 11.249 14.978 9.5 12 9.5c-2.977 0-5.548 1.748-6.758 4.269zM12 10a7 7 0 1 0 0 14 7 7 0 0 0 0-14z"/>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "facebook" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Facebook"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "facebook" }}
           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-brand-facebook" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
             <path d="M7 10v4h3v7h4v-7h3l1 -4h-4v-2a1 1 0 0 1 1 -1h3v-4h-3a5 5 0 0 0 -5 5v2h-3"></path>
           </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "behance" }}
-      <li>
-        <a
-          href="{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="Behance"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300"
-        >
+          {{ if eq .website "behance" }}
           <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-brand-behance" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
             <path d="M3 18v-12h4.5a3 3 0 0 1 0 6a3 3 0 0 1 0 6h-4.5"></path>
@@ -494,24 +325,17 @@
             <path d="M14 13h7a3.5 3.5 0 0 0 -7 0v2a3.5 3.5 0 0 0 6.64 1"></path>
             <line x1="16" y1="6" x2="19" y2="6"></line>
         </svg>
-        </a>
-      </li>
-      {{ end }}
+          {{ end }}
 
-      {{ if eq .website "email" }}
-      <li>
-        <a
-          href="mailto:{{ .url }}"
-          target="_blank"
-          rel="noopener"
-          aria-label="email"
-          class="p-1 inline-block rounded-full border border-transparent text-gray-500 hover:text-gray-800 hover:border-gray-800 cursor-pointer transition-colors dark:text-gray-600 dark:hover:border-gray-300 dark:hover:text-gray-300">
+          {{ if eq .website "email" }}
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-envelope" viewBox="0 0 16 16">
           <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4Zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2Zm13 2.383-4.708 2.825L15 11.105V5.383Zm-.034 6.876-5.64-3.471L8 9.583l-1.326-.795-5.64 3.47A1 1 0 0 0 2 13h12a1 1 0 0 0 .966-.741ZM1 11.105l4.708-2.897L1 5.383v5.722Z"/>
           </svg>
+          {{ end }}
+
+          &nbsp;{{ .label | default .website }}
         </a>
       </li>
-      {{ end }}
 
 {{end}}
     </ul>


### PR DESCRIPTION
Updates the links on our about page to include the JISC mailing list

![image](https://github.com/user-attachments/assets/828a28c6-be8e-482d-bb83-47803437ace1)

and also links to the about page from the front page

![image](https://github.com/user-attachments/assets/21cf78ea-c534-4d69-9de5-05d34bd3df34)

there's also some formatting changes to improve the icon links in the footer

![image](https://github.com/user-attachments/assets/c98d2a35-3e11-4342-9f58-88c5e30a80e9)
